### PR TITLE
Hardlink support, and QOL changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 
 .venv
 client.ini
+build
+dist
+*.spec

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+.venv
+client.ini

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -121,19 +121,9 @@ def are_all_paths_same(
     file_identifiers = set()
     for path in paths:
         try:
-            # Resolve symlinks to their target
             resolved_path: Path = Path(path).resolve(strict=True)
-            # Use os.stat to get file statistics. The follow_symlinks=False argument
-            # is not necessary here since Path.resolve() already resolves them,
-            # but it's used to emphasize the behavior.
-            file_stat = os.stat(resolved_path, follow_symlinks=False)
-
-            # Check os.name to adjust behavior if necessary (mainly for readability and future adjustments)
-            if os.name == "nt":  # Windows
-                file_identifier: tuple[int, int] = (file_stat.st_dev, file_stat.st_ino)
-            else:  # POSIX (Linux, macOS, etc.)
-                file_identifier = (file_stat.st_dev, file_stat.st_ino)
-
+            file_stat = os.stat(resolved_path, follow_symlinks=True)
+            file_identifier: tuple[int, int] = (file_stat.st_dev, file_stat.st_ino)
             file_identifiers.add(file_identifier)
         except FileNotFoundError:
             # Handle the case where the path does not exist

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -116,7 +116,7 @@ def match(
                 },
             ]
             response = prompt(question)
-            if response == "<Skip this file>":
+            if response["file"] == "<Skip this file>":
                 print("user chose to skip, continuing with next torrent...")
                 continue
             

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -105,8 +105,7 @@ def windows_get_size_on_disk(file_path: os.PathLike | str) -> int:
     return size_on_disk
 
 def get_size_on_disk(file_path: os.PathLike | str):
-    """Returns the size on disk of the file at file_path in bytes.
-    """
+    """Returns the size on disk of the file at file_path in bytes."""
     if os.name == "posix":
         # st_blocks are 512-byte blocks
         return os.stat(file_path).st_blocks * 512  # type: ignore[attr-defined]
@@ -136,8 +135,7 @@ def are_all_paths_same(
 def hardlink_largest_file(
     matching_files: list[str] | list[Path | str] | list[Path],
 ):
-    """Find the largest file by 'size on disk' among matching_files and hardlink it.
-    """
+    """Find the largest file by 'size on disk' among matching_files and hardlink it."""
     existing_files: list[str | Path] = [file for file in matching_files if Path(file).exists()]
     if not existing_files:
         return
@@ -160,6 +158,15 @@ def hardlink_largest_file(
         # Create hardlink
         print(f"Creating hardlink for '{largest_file}' <-> '{file}'")
         os.link(largest_file, file_path)
+
+def is_relative_to(path1: Path, path2: Path) -> bool:
+    """pathlib.Path in later versions of python already have this builtin"""
+    try:  # pylint: disable=R1705
+        path1.relative_to(path2)
+    except ValueError:
+        return False
+    else:
+        return True
 
 def get_matching_files_in_dir_and_subdirs(
     search_path: Path,
@@ -322,14 +329,6 @@ def match(
 
     return made_change
 
-def is_relative_to(path1: Path, path2: Path) -> bool:
-    try:  # pylint: disable=R1705
-        path1.relative_to(path2)
-    except ValueError:
-        return False
-    else:
-        return True
-
 def set_search_and_download_paths(
     torrent: TorrentDictionary,
     input_search_path: Path | None,
@@ -391,6 +390,8 @@ def matcher(
         print("Connected to api!")
         if not torrents:
             sys.exit(f"{Fore.RED}No torrents found found anywhere in your qBittorrent{Style.RESET_ALL}")
+    else:
+        sys.exit("Nothing to do?")
 
     for torrent in torrents:
         torrent_hash = torrent["hash"].upper()

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -225,11 +225,10 @@ def match(
             )
             and disk_file_abs_path not in matched_files
         ]
-        if are_all_paths_same(matching_files):
-            continue  # all hard/symlinked to the same file.
 
         if len(matching_files) > 1:
-
+            if are_all_paths_same(matching_files):
+                continue  # all hard/symlinked to the same file.
             subfolder_to_ignore: Path = Path(matching_files[0]).parent
             if subfolder_to_ignore in IGNORED_SUBFOLDERS:
                 continue

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -119,9 +119,9 @@ def match(
             subfolder_ignore_question = f"<Ignore all files in '{subfolder_to_ignore}'>"
             extension_ignore_question = f"<Ignore all files with '{extension_to_ignore}' extensions>"
 
-            matching_files.insert(0, "<Skip this file>")
-            matching_files.insert(1, subfolder_ignore_question)
-            matching_files.insert(2, extension_ignore_question)
+            matching_files.append("<Skip this file>")
+            matching_files.append(subfolder_ignore_question)
+            matching_files.append(extension_ignore_question)
             print("\n")
             question: list[dict[str, Any]] = [
                 {

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 try:
     from colorama import Fore, Style, init
     from InquirerPy.resolver import prompt
-    from qbittorrentapi import Client, TorrentDictionary, TorrentFile
+    from qbittorrentapi import Client, Conflict409Error, TorrentDictionary, TorrentFile
 except (ImportError, ModuleNotFoundError):
     print(traceback.format_exc())
     print("You need to install the dependencies.")
@@ -162,8 +162,12 @@ def match(
             print(f"{Fore.YELLOW}Dry run:{Style.RESET_ALL}\n{torrent_file.name} ->\n{Fore.YELLOW}{new_relative_path}{Style.RESET_ALL}")
             continue
 
-        print(f"Renaming file:\n{torrent_file.name} ->\n{Fore.GREEN}{new_relative_path}{Style.RESET_ALL}")
-        torrent.rename_file(file_id=torrent_file.id, new_file_name=new_relative_path)  # type: ignore[reportCallIssue]
+        try:
+            torrent.rename_file(file_id=torrent_file.id, new_file_name=new_relative_path)  # type: ignore[reportCallIssue]
+        except Conflict409Error as e:
+            print(f"{Fore.RED}Skipping {torrent_file.name} due to error:", e)
+        else:
+            print(f"Renaming file:\n{torrent_file.name} ->\n{Fore.GREEN}{new_relative_path}{Style.RESET_ALL}")
 
 def is_relative_to(path1: Path, path2: Path):
     try:  # pylint: disable=R1705

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -106,6 +106,7 @@ def match(
             )
         ]
         if len(matching_files) > 1:
+            matching_files.insert(0, "<Skip this file>")
             question: list[dict[str, Any]] = [
                 {
                     "type": "list",
@@ -115,7 +116,13 @@ def match(
                 },
             ]
             response = prompt(question)
+            if response == "<Skip this file>":
+                print("user chose to skip, continuing with next torrent...")
+                continue
+            
             selected_file_path = response["file"]
+            assert isinstance(selected_file_path, str)
+
         elif matching_files:
             selected_file_path = matching_files[0]
 

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -285,8 +285,11 @@ def match(
             selected_file_path = matching_files[0]
 
         else:
-            print(f"{Fore.YELLOW}No matches found for '{original_relpath_str}'! setting file priority of {torrent_file.id} to 0.{Style.RESET_ALL}")
-            if not is_dry_run and no_redownload:
+            print(f"{Fore.YELLOW}No matches found for '{original_relpath_str}'!{Style.RESET_ALL}")
+            if no_redownload:
+                print(f"setting file priority of {torrent_file.id} to 0.")
+                if is_dry_run:
+                    continue
                 torrent.file_priority(
                     file_id=torrent_file.id,
                     priority=0,
@@ -439,7 +442,7 @@ def matcher(
             qb_client.torrents_set_location(torrent_hashes=torrent_hash, location=str(input_download_path))
             print(f"{Fore.LIGHTMAGENTA_EX}Rechecking torrent{Style.RESET_ALL}")
             qb_client.torrents_recheck(torrent_hash)
-        elif made_change:
+        elif made_change and not is_dry_run:
             print("Change made, rechecking torrent...")
             qb_client.torrents_recheck(torrent_hash)
         if is_dry_run:

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -144,21 +144,21 @@ def hardlink_largest_file(
     if not largest_file.exists():
         return
     for file in matching_files:
-        if file == largest_file:
+        r_file = Path(file).resolve()
+        if r_file == largest_file:
             continue
 
-        file_path = Path(file)
-        file_path.parent.mkdir(exist_ok=True, parents=True)
-        if file_path.exists() and file_path.is_dir():  # unlink will fail if it's somehow a folder.
+        r_file.parent.mkdir(exist_ok=True, parents=True)
+        if r_file.exists() and r_file.is_dir():  # unlink will fail if it's somehow a folder.
             print(f"'{file}' is somehow a directory, rmdir()")
-            file_path.rmdir()
+            r_file.rmdir()
         else:
             print(f"Deleting file '{file}'")
-            file_path.unlink(missing_ok=True)
+            r_file.unlink(missing_ok=True)
 
         # Create hardlink
         print(f"Creating hardlink for '{largest_file}' <-> '{file}'")
-        os.link(largest_file, file_path)
+        os.link(largest_file, r_file)
 
 def is_relative_to(path1: Path, path2: Path) -> bool:
     """pathlib.Path in later versions of python already have this builtin"""

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -367,7 +367,7 @@ def matcher(
         if not torrents:
             sys.exit(f"{Fore.RED}No torrents found found anywhere in your qBittorrent{Style.RESET_ALL}")
     else:
-        print("Nothing to do? (check the cmdline args passed)")
+        print("Nothing to do? (send -a or an input torrent hash/file)")
         return
 
     for torrent in torrents:

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -1,103 +1,124 @@
+from __future__ import annotations
+
 import argparse
 import configparser
 import os
 import sys
+import traceback
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 try:
     from colorama import Fore, Style, init
-    from InquirerPy import prompt
-    from qbittorrentapi import Client
-except ModuleNotFoundError:
+    from InquirerPy.resolver import prompt
+    from qbittorrentapi import Client, TorrentDictionary, TorrentFile
+except (ImportError, ModuleNotFoundError):
+    print(traceback.format_exc())
     print("You need to install the dependencies.")
     print("If you have pip (normally installed with python), run this command in a terminal (cmd):")
-    print('pip install colorama inquirerpy qbittorrent-api')
+    print("pip install colorama inquirerpy qbittorrent-api")
     sys.exit()
 
-def get_config():
-    default_config = {
-        'Client': {
-            'host': 'localhost:8080',
-            'username': 'admin',
-            'password': 'adminadmin'
-        }
+if TYPE_CHECKING:
+    from qbittorrentapi import TorrentInfoList
+
+def get_config() -> tuple[str, str, str]:
+    default_config: dict[str, dict[str, str]] = {
+        "Client": {
+            "host": "localhost:8080",
+            "username": "admin",
+            "password": "adminadmin",
+        },
     }
-    config_file = 'client.ini'
-    
+    config_file = "client.ini"
+
     config = configparser.ConfigParser()
 
     if not os.path.exists(config_file):
-        print('client.ini not found')
+        print("client.ini not found")
         make_new_config(default_config, config, config_file)
 
     config.read(config_file)
-    host = config.get('Client', 'host', fallback=default_config['Client']['host'])
-    username = config.get('Client', 'username', fallback=default_config['Client']['username'])
-    password = config.get('Client', 'password', fallback=default_config['Client']['password'])
+    host = config.get("Client", "host", fallback=default_config["Client"]["host"])
+    username = config.get("Client", "username", fallback=default_config["Client"]["username"])
+    password = config.get("Client", "password", fallback=default_config["Client"]["password"])
 
     return host, username, password
 
 def make_new_config(default_config, config, config_file):
     host = input(f"Enter qBittorrent Web UI host (Empty to use {default_config['Client']['host']}): ")
-    host = host.strip() or default_config['Client']['host']
+    host = host.strip() or default_config["Client"]["host"]
     print(f"Using qBittorrent Web UI host: {host}")
 
     username = input(f"Enter qBittorrent Web UI username (Empty to use {default_config['Client']['username']}): ")
-    username = username.strip() or default_config['Client']['username']
+    username = username.strip() or default_config["Client"]["username"]
     print(f"Using qBittorrent Web UI username: {username}")
 
     password = input(f"Enter qBittorrent Web UI password (Empty to use {default_config['Client']['password']}): ")
-    password = password.strip() or default_config['Client']['password']
+    password = password.strip() or default_config["Client"]["password"]
     print("Using qBittorrent Web UI password: *****")  # For security, we only print asterisks for the password
 
     # Save the new credentials to client.ini
-    config['Client'] = {}
-    config['Client']['host'] = host
-    config['Client']['username'] = username
-    config['Client']['password'] = password
-    with open(config_file, 'w') as f:
+    config["Client"] = {}
+    config["Client"]["host"] = host
+    config["Client"]["username"] = username
+    config["Client"]["password"] = password
+    with open(config_file, "w", encoding="utf-8") as f:
         config.write(f)
     print("client.ini created")
 
-def init_client():
+def init_client() -> Client:
     host, username, password = get_config()
     return Client(host=host, username=username, password=password)
 
 
-def get_matching_files_in_dir_and_subdirs(search_path, sizes):
-    files_in_directory = [os.path.join(dirpath, name) for dirpath, _, filenames in os.walk(search_path) for name in filenames]
+def get_matching_files_in_dir_and_subdirs(search_path, sizes: set[int]) -> list[tuple[str, int]]:
+    files_in_directory: list[str] = [os.path.join(dirpath, name) for dirpath, _, filenames in os.walk(search_path) for name in filenames]
     print(f"Found {len(files_in_directory)} files in the search directory")
 
-    files_and_sizes = map(lambda file: [file, os.path.getsize(file)], files_in_directory)
+    files_and_sizes = map(lambda file: (file, os.path.getsize(file)), files_in_directory)
 
-    matched_files = [pair for pair in files_and_sizes if pair[1] in sizes]
-    return matched_files
+    return [pair for pair in files_and_sizes if pair[1] in sizes]
 
-def match(torrent, files_in_directory, match_extension, download_path, is_dry_run):
+def match(
+    torrent: TorrentDictionary,
+    files_in_directory,
+    match_extension,
+    download_path,
+    is_dry_run: bool,
+) -> None:
     matched_files = set()  # keep track of already matched files
+    torrent_file: TorrentFile
     for torrent_file in torrent.files:
         if torrent_file.priority == 0:
             continue
-        matching_files = []
-        for disk_file_abs_path, disk_file_size in files_in_directory:
-            if (torrent_file.size == disk_file_size and
-                (not match_extension or Path(disk_file_abs_path).suffix == Path(torrent_file.name).suffix) and
-                disk_file_abs_path not in matched_files):
-                matching_files.append(disk_file_abs_path)
 
+        matching_files: list[str] = [
+            disk_file_abs_path
+            for disk_file_abs_path, disk_file_size in files_in_directory
+            if (
+                torrent_file.size == disk_file_size
+                and (
+                    not match_extension
+                    or Path(disk_file_abs_path).suffix == Path(torrent_file.name).suffix
+                )
+                and disk_file_abs_path not in matched_files
+            )
+        ]
         if len(matching_files) > 1:
-            question = [
+            question: list[dict[str, Any]] = [
                 {
                     "type": "list",
                     "message": f"Multiple matches found for {torrent_file.name}. Select a file to match:",
                     "choices": matching_files,
                     "name": "file",
-                }
+                },
             ]
             response = prompt(question)
             selected_file_path = response["file"]
         elif matching_files:
             selected_file_path = matching_files[0]
+
         else:
             print(f"{Fore.RED}No matches found for {torrent_file.name}!{Style.RESET_ALL}")
             continue
@@ -110,94 +131,155 @@ def match(torrent, files_in_directory, match_extension, download_path, is_dry_ru
         if is_dry_run:
             print(f"{Fore.YELLOW}Dry run:{Style.RESET_ALL}\n{torrent_file.name} ->\n{Fore.YELLOW}{new_relative_path}{Style.RESET_ALL}")
             continue
-        print(f"Renaming file:\n{torrent_file.name} ->\n{Fore.GREEN}{new_relative_path}{Style.RESET_ALL}")
-        torrent.rename_file(file_id=torrent_file.id, new_file_name=new_relative_path)
 
-def set_search_and_download_paths(torrent, input_search_path, input_download_path, use_torrent_save_path_as_search_path):
-    content_path = torrent.content_path
-    download_path = torrent.save_path
-    search_path = ''
+        print(f"Renaming file:\n{torrent_file.name} ->\n{Fore.GREEN}{new_relative_path}{Style.RESET_ALL}")
+        torrent.rename_file(file_id=torrent_file.id, new_file_name=new_relative_path)  # type: ignore[reportCallIssue]
+
+def is_relative_to(path1: Path, path2: Path):
+    try:  # pylint: disable=R1705
+        path1.relative_to(path2)
+    except Exception:
+        return False
+    else:
+        return True
+
+def set_search_and_download_paths(
+    torrent: TorrentDictionary,
+    input_search_path: Path | None,
+    input_download_path: Path | None,
+    use_torrent_save_path_as_search_path: bool,
+) -> tuple[Path, Path] | tuple[None, None]:
+    content_path: Path = Path(torrent.content_path)
+    raw_download_path = torrent.save_path
 
     if input_download_path:
-        content_path = str(Path(input_download_path).joinpath(Path(content_path).relative_to(download_path)))
-        download_path = input_download_path
-    if input_search_path and input_search_path.startswith(str(Path(download_path).resolve())):
-        search_path = input_search_path
-    elif input_search_path and not input_search_path.startswith(str(Path(download_path).resolve())):
-        sys.exit(f"Search path {input_search_path} must be sub directory of {download_path}")
-    elif use_torrent_save_path_as_search_path or not Path(content_path).exists():
-        search_path = download_path
-    else:
-        search_path = content_path if Path(content_path).is_dir() else Path(content_path).parent
+        content_path = input_download_path.joinpath(content_path.relative_to(raw_download_path))
+        raw_download_path = input_download_path
 
-    search_path = search_path if Path(search_path).exists() else sys.exit(f"Search path {search_path} does not exist")
-    download_path = download_path if Path(download_path).exists() else sys.exit(f"Download path {download_path} does not exist")
+    download_path: Path = Path(raw_download_path).resolve()
+    search_path: Path | None = None
+    if input_search_path:
+        if not is_relative_to(input_search_path, download_path):
+            print(f"Search path {input_search_path} must be a sub directory of {raw_download_path}\n")
+            return None, None
+        search_path = input_search_path
+
+    elif use_torrent_save_path_as_search_path or not content_path.exists():
+        search_path = download_path
+
+    else:
+        search_path = content_path if content_path.is_dir() else content_path.parent
+
+    if not search_path:
+        sys.exit(f"Search path '{search_path}' does not exist")
+    if not download_path:
+        sys.exit(f"Download path '{download_path}' does not exist")
 
     return search_path, download_path
 
 
-def matcher(input_torrent_hashes = None, sync_all = False, input_search_path = None, input_download_path = None, use_torrent_save_path_as_search_path = False, match_extension = False, is_dry_run = False):
-    qb_client = init_client()
-    print("connected to api")
+def matcher(
+    input_torrent_hashes: list[str],
+    sync_all: bool = False,
+    input_search_path: Path | None = None,
+    input_download_path: Path | None = None,
+    use_torrent_save_path_as_search_path: bool = False,
+    match_extension: bool = False,
+    is_dry_run: bool = False,
+):
+    qb_client: Client = init_client()
+    print("Connected to api!")
     if input_torrent_hashes:
-        torrents = qb_client.torrents.info(torrent_hashes=input_torrent_hashes)
+        torrents: TorrentInfoList = qb_client.torrents.info(torrent_hashes=input_torrent_hashes)
         if not torrents:
-            sys.exit(f"{Fore.RED}No torrents found with any the given hashes{Style.RESET_ALL}")
+            sys.exit(f"{Fore.RED}No torrents found matching any of the provided hashes.{Style.RESET_ALL}")
         else:
-            found_hashes = [torrent['hash'] for torrent in torrents]  # Extracting found hashes
+            found_hashes: list[str] = [torrent["hash"].upper() for torrent in torrents]  # Extracting found hashes
             for hash_value in input_torrent_hashes:
                 if hash_value not in found_hashes:
-                    print(f"{Fore.RED}Torrent with hash {hash_value} not found{Style.RESET_ALL}")
+                    print(f"{Fore.RED}Torrent with hash '{hash_value}' not found.{Style.RESET_ALL}")
     elif sync_all:
         torrents = qb_client.torrents_info()
         if not torrents:
-            sys.exit(f"{Fore.RED}No torrents found{Style.RESET_ALL}")
+            sys.exit(f"{Fore.RED}No torrents found found anywhere in your qBittorrent{Style.RESET_ALL}")
+    else:
+        print("Nothing to do? (check the cmdline args passed)")
+        return
+
     for torrent in torrents:
-        torrent_hash = torrent['hash']
-        print(f"Target torrent: {torrent.name}")
-        search_path , download_path = set_search_and_download_paths(torrent, input_search_path, input_download_path, use_torrent_save_path_as_search_path)
-        print(f"Search directory {search_path}\nDownload directory {download_path}")
-        torrent_file_sizes = set(file.size for file in torrent.files)
+        torrent_hash = torrent["hash"]
+        print(f"\nTarget torrent: {torrent.name}")
+        search_path , download_path = set_search_and_download_paths(
+            torrent,
+            input_search_path,
+            input_download_path,
+            use_torrent_save_path_as_search_path
+        )
+        if not search_path or not download_path:
+            # print(f"Skipping '{torrent.name}', no search path determined.\n")
+            continue
+
+        print(f"Search directory '{search_path}'\nDownload directory '{download_path}'")
+
+        # Unfortunately hashing individual files isn't possible (or at least practical), so we match with their sizes.
+        # Probably need a minimum size to consider, otherwise it'll always match 0-byte files.
+        torrent_file_sizes: set[int] = {file.size for file in torrent.files}
+
         print("Scanning files in search directory")
-        files_in_directory = get_matching_files_in_dir_and_subdirs(search_path, torrent_file_sizes)
-        print("Looking for matches")
+        files_in_directory: list[tuple[str, int]] = get_matching_files_in_dir_and_subdirs(search_path, torrent_file_sizes)
+        print(f"Found {len(files_in_directory)} matches in '{search_path}'")
+
+        print("Executing matchmaking logic...")
         match(torrent, files_in_directory, match_extension, download_path, is_dry_run)
+
         if input_download_path and input_download_path != torrent.save_path and not is_dry_run:
             print(f"Changing torrent save location to {input_download_path}")
-            qb_client.torrents_set_location(torrent_hashes=torrent_hash, location=input_download_path)
+            qb_client.torrents_set_location(torrent_hashes=torrent_hash, location=str(input_download_path))
             print(f"{Fore.LIGHTMAGENTA_EX}Rechecking torrent{Style.RESET_ALL}")
             qb_client.torrents_recheck(torrent_hash)
         if is_dry_run:
             print(f"{Fore.YELLOW}Performed a dry run, nothing was modified{Style.RESET_ALL}")
 
 
-def main():
-    init() #colorama
+def main() -> None:
+
+    init()  # colorama
+
     parser = argparse.ArgumentParser(description="Tool to match torrents added to qBittorent to files on a disk")
-    parser.add_argument('input', nargs='?', default=None, help='Torrent hash, or a txt with a list of hashes.')
-    parser.add_argument('-a', '-all', action='store_true', help="Look for matches for every qBT torrent. Ignored if used with input hash(es).")
-    parser.add_argument('-s', '-spath', default=None, help="Specifies search path. Must be a subpath of the download path.")
-    parser.add_argument('-d', '-dpath', default=None, help="Sets new download path for the torrent.")
-    parser.add_argument('-fd', action='store_true', help="Forces search in torrent's download directory. Default is torrent's content directory. Ignored if passed along with search.")
-    parser.add_argument('-e', '-ext', action='store_true', help="Forces matched files to share an extension.")
-    parser.add_argument('-dry', action='store_true', help="Performs a dry run without modifying anything.")
+    parser.add_argument("input", nargs="?", default=None, help="Torrent hash, or a txt with a list of hashes.")
+    parser.add_argument("-a", "-all", action="store_true", help="Look for matches for every qBT torrent. Ignored if used with input hash(es).")
+    parser.add_argument("-s", "-spath", default=None, help="Specifies search path. Must be a subpath of the download path.")
+    parser.add_argument("-d", "-dpath", default=None, help="Sets new download path for the torrent.")
+    parser.add_argument("-fd", action="store_true", help="Forces search in torrent's download directory. Default is torrent's content directory. Ignored if passed along with search.")
+    parser.add_argument("-e", "-ext", action="store_true", help="Forces matched files to share an extension.")
+    parser.add_argument("-dry", action="store_true", help="Performs a dry run without modifying anything.")
 
     args = parser.parse_args()
 
-    if args.input and os.path.isfile(args.input):
-        with open(args.input, "r") as file:
-            hashes = [line.strip() for line in file if line.strip()]
+    path: Path | None = Path(args.input) if args.input else None
+    if path and path.exists() and path.is_file():  # TODO: determine whether it's a hash or a filepath.
+        with path.open(mode="r", encoding="utf-8") as file:
+            hashes: list[str] = [line.strip().upper() for line in file if line.strip()]
     else:
-        hashes = [args.input] if args.input else None
+        hashes = [args.input.upper()] if args.input else []
+    
+    input_search_path: Path | None = Path(args.s) if args.s else None
+    if input_search_path and (not input_search_path.exists() or input_search_path.is_file()):
+        sys.exit(f"bad search path: '{input_search_path}' (either nonexistent or not a directory)")
+
+    input_download_path: Path | None = Path(args.d) if args.d else None
+    if input_download_path and (not input_download_path.exists() or input_download_path.is_file()):
+        sys.exit(f"bad download path: '{input_download_path}' (either nonexistent or not a directory)")
+
     matcher(
-        input_torrent_hashes = hashes,
-        sync_all = args.a,
-        input_search_path = args.s,
-        input_download_path = args.d,
-        use_torrent_save_path_as_search_path = args.fd,
-        match_extension = args.e,
-        is_dry_run = args.dry
-        )
+        hashes,
+        args.a,
+        input_search_path,
+        input_download_path,
+        args.fd,
+        args.e,
+        args.dry,
+    )
 
 if __name__ == "__main__":
     main()

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -116,8 +116,8 @@ def match(
             subfolder_to_ignore: Path = Path(matching_files[0]).parent
             extension_to_ignore: str = Path(torrent_file.name).suffix.lower()
 
-            subfolder_ignore_question = f"<Ignore all files in '{subfolder_to_ignore}'>"
-            extension_ignore_question = f"<Ignore all files with '{extension_to_ignore}' extensions>"
+            subfolder_ignore_question = f"<Don't ask again for all files in '{subfolder_to_ignore}'>"
+            extension_ignore_question = f"<Don't ask again for all files with '{extension_to_ignore}' extensions>"
 
             matching_files.append("<Skip this file>")
             matching_files.append(subfolder_ignore_question)

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -275,7 +275,7 @@ def match(
                 continue
             if response["file"] == hardlink_option:
                 hardlink_largest_file(matching_files)
-                made_change = True
+                #made_change = True
                 continue
 
             selected_file_path = response["file"]
@@ -287,14 +287,14 @@ def match(
         else:
             print(f"{Fore.YELLOW}No matches found for '{original_relpath_str}'!{Style.RESET_ALL}")
             if no_redownload:
-                print(f"setting file priority of '{torrent_file.id}' to 0.")
+                print(f"setting file priority of '{torrent_file.name}' to 0.")
                 if is_dry_run:
                     continue
                 torrent.file_priority(
-                    file_id=torrent_file.id,
+                    file_ids=int(torrent_file.index),
                     priority=0,
                 )  # type: ignore[reportCallIssue]
-                made_change = True
+                #made_change = True
             continue
 
         matched_files.add(selected_file_path)
@@ -313,7 +313,7 @@ def match(
             print(f"Hardlinking file:\n{original_relpath_str} <--vv\n{Fore.GREEN}{new_relative_path_str}{Style.RESET_ALL}")
             args_list: list[Path | str] = [original_file_path, selected_file_path]
             hardlink_largest_file(args_list)
-            made_change = True
+            #made_change = True
             continue
 
         try:
@@ -336,17 +336,17 @@ def match(
             if response[0] == "yes":
                 args_list = [original_file_path, selected_file_path]
                 hardlink_largest_file(args_list)
-                made_change = True
+                #made_change = True
             elif no_redownload:
-                print(f"setting file priority of '{torrent_file.id}' to 0.")
+                print(f"setting file priority of '{torrent_file.name}' to 0.")
                 torrent.file_priority(
-                    file_id=torrent_file.id,
+                    file_ids=torrent_file.index,
                     priority=0,
                 )  # type: ignore[reportCallIssue]
-                made_change = True
+                #made_change = True
         else:
             print(f"Renaming file:\n{original_relpath_str} ->\n{Fore.GREEN}{new_relative_path}{Style.RESET_ALL}")
-            made_change = True
+            #made_change = True
 
     return made_change
 
@@ -443,9 +443,11 @@ def matcher(
             qb_client.torrents_set_location(torrent_hashes=torrent_hash, location=str(input_download_path))
             print(f"{Fore.LIGHTMAGENTA_EX}Rechecking torrent{Style.RESET_ALL}")
             qb_client.torrents_recheck(torrent_hash)
+
         elif made_change and not is_dry_run:
             print("Change made, rechecking torrent...")
             qb_client.torrents_recheck(torrent_hash)
+
         if is_dry_run:
             print(f"{Fore.YELLOW}Performed a dry run, nothing was modified{Style.RESET_ALL}")
 

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -287,7 +287,7 @@ def match(
         else:
             print(f"{Fore.YELLOW}No matches found for '{original_relpath_str}'!{Style.RESET_ALL}")
             if no_redownload:
-                print(f"setting file priority of {torrent_file.id} to 0.")
+                print(f"setting file priority of '{torrent_file.id}' to 0.")
                 if is_dry_run:
                     continue
                 torrent.file_priority(
@@ -338,6 +338,7 @@ def match(
                 hardlink_largest_file(args_list)
                 made_change = True
             elif no_redownload:
+                print(f"setting file priority of '{torrent_file.id}' to 0.")
                 torrent.file_priority(
                     file_id=torrent_file.id,
                     priority=0,


### PR DESCRIPTION
- Added static typing annotations where relevant.
- Created a `is_relative_to` function for better checks (comparing the result of `str(Path("path/to/file").resolve().startswith(other_path))` wasn't working on my arch linux setup.
- Added a way to skip files in the prompt. You'll now see:
  - `<Skip this file>`
  - `<Don't ask again (skip) for all files in (the subfolder)>`
  - `<Don't ask again for all extensions matching .(the extension)>`
- Added a feature to skip torrents that don't match the search path `-s`. Otherwise it used to just crash
- Catch `Conflict409` exceptions when the rename call api fails. Used to just crash outright.
- Add `-nodl`: if the file isn't found on disk, tell qBittorrent to set priority of that file to *Do not download this file*.
- Add hardlink support `-l`.
  - If a file already exists, prompt to hardlink.
  - If user chooses <hardlink all files (experimental)>, will find the largest file (using the size on disk to determine) and hardlink that one to all the others. This is useful if the user is downloading multiple torrents that have some matching files, and they haven't finished downloading some or all of them.

and finally ran it through `ruff check . --fix --select ALL` to help readability.

Basically I had a scenario where I usually seed hundreds of torrents, but the PC died along with qBittorrent's torrent metadata. Luckily the external HDD survived, now I'm just trying to match them up with all of their original torrents. Your script has helped immensely with this, especially that undocumented `-a` option.