### PR TITLE
Add Priority and Delete Option for Matching Torrent Files

### DIFF
--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -186,8 +186,12 @@ def get_matching_files_in_dir_and_subdirs(
 
     files_and_sizes: list[tuple[str, int]] = []
     for file in files_in_directory:
-        size: int = os.path.getsize(file)
-        if size <= 512 and use_hardlinks:  # don't do anything with small files if hardlinking.
+        try:
+            size: int = os.path.getsize(file)
+            if size <= 512 and use_hardlinks:  # don't do anything with small files if hardlinking.
+                continue
+        except FileNotFoundError as e:
+            print(f"{Fore.RED}Somehow os.walk found a file that does not exist: {e}{Fore.RESET}")
             continue
         files_and_sizes.append((file, size))
 

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -16,7 +16,7 @@ if os.name == "nt":
     from ctypes import wintypes
 
 if sys.version_info < (3, 7, 0):
-    sys.exit("This script requires at least python 3.7, you are running {sys.version_info}. Please upgrade your Python installation.")
+    sys.exit(f"This script requires at least python 3.7, you are running {sys.version_info}. Please upgrade your Python installation.")
 
 try:  # sourcery skip: remove-redundant-exception, simplify-single-exception-tuple
     from colorama import Fore, Style, init

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -4,9 +4,9 @@ import argparse
 import configparser
 import os
 import sys
-from time import sleep
 import traceback
 from pathlib import Path, PurePath, PureWindowsPath
+from time import sleep
 from typing import TYPE_CHECKING, Any
 
 from qbittorrentapi import TorrentFilesList
@@ -30,6 +30,8 @@ except (ImportError, ModuleNotFoundError):
     sys.exit()
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from qbittorrentapi import TorrentInfoList
 
 def get_config() -> tuple[str, str, str]:
@@ -117,7 +119,7 @@ def get_size_on_disk(file_path: os.PathLike | str):
 
 # From stackoverflow.
 def are_all_paths_same(
-    paths: list[os.PathLike | str] | list[str] | list[os.PathLike],
+    paths: Sequence[os.PathLike | str],
 ) -> bool:
     # sourcery skip: assign-if-exp, hoist-statement-from-if, remove-redundant-condition
     file_identifiers = set()

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -315,7 +315,7 @@ def match(
         new_relative_path: Path = Path(selected_file_path).relative_to(download_path)
         new_relative_path_str: str = new_relative_path.as_posix()
         if new_relative_path == original_relpath:
-            print(f"{original_relpath_str} already synced, left as is")
+            #print(f"{original_relpath_str} already synced, left as is")
             continue
 
         if is_dry_run:

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -592,7 +592,7 @@ def main() -> None:
                 priority_value = int(priority)  # Convert priority to an integer
             except ValueError:  # not an int
                 if priority.upper() != "DELETE":
-                    raise ValueError(f"Bad priority value {priority_value}, expected a number between 0-3 or literal str 'DELETE'")
+                    raise ValueError(f"Bad priority value {priority}, expected a number between 0-3 or literal str 'DELETE'")
                 delete_file = True
                 priority_value = 0
             pattern_path = Path(pattern)

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -487,19 +487,22 @@ def matcher(
                         continue
                     if not t_absolute_path.exists() or not t_absolute_path.is_file():
                         continue
-                    qb_client.torrents_pause(  # type: ignore[reportCallIssue]
-                        torrent_hashes=torrent_hash,
-                    )
-                    sleep(1)
+                    if os.name == "nt":
+                        # We must pause as qb could still be accessing the file...
+                        qb_client.torrents_pause(  # type: ignore[reportCallIssue]
+                            torrent_hashes=torrent_hash,
+                        )
+                        sleep(1)  # Wait for the torrent to pause.
                     try:
                         t_absolute_path.unlink(missing_ok=True)
                     except PermissionError as e:
                         print(f"{Fore.RED}Error: {e}{Style.RESET_ALL}")
                     else:
                         print(f"{Fore.MAGENTA}Deleted '{t_absolute_path}'{Style.RESET_ALL}")
-                    qb_client.torrents_resume(  # type: ignore[reportCallIssue]
-                        torrent_hashes=torrent_hash,
-                    )
+                    if os.name == "nt":
+                        qb_client.torrents_resume(  # type: ignore[reportCallIssue]
+                            torrent_hashes=torrent_hash,
+                        )
             continue  # priority settings aren't compatible with any other cli args (yet)
         search_path , download_path = set_search_and_download_paths(
             torrent,

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -530,9 +530,8 @@ def matcher(
         # Unfortunately hashing individual files isn't possible (or at least practical), so we match with their sizes.
         torrent_file_sizes: set[int] = {file.size for file in torrent.files if file.size}
 
-        print("Scanning files in search directory")
         files_in_directory: list[tuple[str, int]] = get_matching_files_in_dir_and_subdirs(search_path, torrent_file_sizes, use_hardlinks)
-        print(f"Found {len(files_in_directory)} matches in '{search_path}'")
+        print(f"Found {len(files_in_directory)} matches in search path '{search_path}'")
         made_change: bool = match(torrent, files_in_directory, match_extension, download_path, use_hardlinks, is_dry_run, no_redownload)
 
         if input_download_path and input_download_path != torrent.save_path and not is_dry_run:

--- a/qbittorrent_file_matcher.py
+++ b/qbittorrent_file_matcher.py
@@ -475,8 +475,6 @@ def matcher(
                             priority=priority_value,
                         )  # type: ignore[reportCallIssue]
                         continue
-                    else:
-                        ...
                 if not delete_pattern_found:  # Don't delete files when the pattern wasn't found. Stops unrelated 0-priority files that weren't scanned from being deleted.
                     continue
                 torlist: TorrentFilesList = qb_client.torrents.files(torrent_hash, indexes=torrent_file.index)  # type: ignore[reportArgumentType]


### PR DESCRIPTION
This update introduces a new command-line argument, -p/--priority, to the qBittorrent File Matcher script. This feature allows users to set the priority of files within a torrent that match a specified pattern. Additionally, users can opt to delete files directly by specifying 'DELETE' as an action.

Usage
The -p/--priority argument requires two parameters: the pattern to match and the action to take. The action can be a priority level (0-4) or the word 'DELETE' to remove the matching files. If delete is selected, priority will also be set to zero.

Syntax:
```
-p PATTERN ACTION
--priority PATTERN ACTION
```

Parameters:
PATTERN: The string pattern to match against file names in the torrent.
ACTION: A priority level (0-4) to set for matching files. 'DELETE' to remove matching files from the disk.  If delete is selected, priority will also be set to zero.

Examples
Set Priority: To set a priority of 2 for all files containing the string 'sample':
```
-p sample 2
```
This command will search for files within the torrent that contain 'sample' in their name and set their download priority to 2.

Delete Files: To delete all files containing the string 'temp':
```
-p temp DELETE
```
This command will search for and delete all files in the torrent that contain 'temp' in their name. and set their priority to zero.

This parameter is not compatible with most other args, except the input hashes of course.